### PR TITLE
protect against exception in RooDataSet::initialize when no weight variable specified

### DIFF
--- a/core/Data.cpp
+++ b/core/Data.cpp
@@ -115,7 +115,9 @@ namespace HS{
      while(auto* arg=dynamic_cast<RooAbsArg*>(iter()))	
        rawtree->SetBranchStatus(arg->GetName(),true);	
 
-     auto ds=std::unique_ptr<RooDataSet>(new RooDataSet{"DataEvents","DataEvents", rawtree,vars, fSetup->DataCut(),fInWeightName});
+     auto ds=std::unique_ptr<RooDataSet>(new RooDataSet{
+       "DataEvents","DataEvents", rawtree,vars, fSetup->DataCut(), fInWeightName==""?0:fInWeightName.Data()
+     });
 
      fFiledTrees[iset].reset(); //delete rawtree 
      if(fInWeights.get()){


### PR DESCRIPTION
Some changes appeared in newer versions of `root` (testing v6.24/02). In particular, an exception is now thrown in `RooDataSet::initialize` when it tries to look for a weight and cannot find it. 

When no weight variable is specified, an empty TString is passed to `RooDataSet::initialize`, but it still tries to look for the weight variable, rather than ignoring it. Explicitly sending it `0` when no weight is specified causes the correct behavior.