### PR TITLE
make MCMCTree disk resident

### DIFF
--- a/core/RooMcmc.cpp
+++ b/core/RooMcmc.cpp
@@ -22,6 +22,7 @@ namespace HS{
 	for(auto br:_formBranches)
 	  delete br;
       }
+      if(fTreeMCMCfile){ fTreeMCMCfile->Close(); delete fTreeMCMCfile;}
     }
     
     void RooMcmc::Run(Setup &setup,RooAbsData &fitdata){
@@ -97,7 +98,6 @@ namespace HS{
       fChainData=fChain->GetAsDataSet(EventRange(0, fChain->Size()));
 
       if(fChainData){
-	if(fTreeMCMCfile){ delete fTreeMCMCfile; fTreeMCMCfile=nullptr;}
 	if(fTreeMCMC){ delete fTreeMCMC; fTreeMCMC=nullptr;}
 	
 	TString fileName=fSetup->GetOutDir()+fSetup->GetName()+"/Results"+fSetup->GetTitle()+GetName()+".root";

--- a/core/RooMcmc.cpp
+++ b/core/RooMcmc.cpp
@@ -97,8 +97,11 @@ namespace HS{
       fChainData=fChain->GetAsDataSet(EventRange(0, fChain->Size()));
 
       if(fChainData){
+	if(fTreeMCMCfile){ delete fTreeMCMCfile; fTreeMCMCfile=nullptr;}
 	if(fTreeMCMC){ delete fTreeMCMC; fTreeMCMC=nullptr;}
 	
+	TString fileName=fSetup->GetOutDir()+fSetup->GetName()+"/Results"+fSetup->GetTitle()+GetName()+".root";
+	fTreeMCMCfile = new TFile(fileName,"RECREATE");
  	fTreeMCMC=RooStats::GetAsTTree("MCMCTree","MCMCTree",*fChainData);
 	delete fChainData; fChainData=nullptr;
       }  
@@ -330,8 +333,8 @@ namespace HS{
     ///////////////////////////////////////////////////////////////
     file_uptr RooMcmc::SaveInfo(){
       
-      TString fileName=fSetup->GetOutDir()+fSetup->GetName()+"/Results"+fSetup->GetTitle()+GetName()+".root";
-      file_uptr file(TFile::Open(fileName,"recreate"));
+      file_uptr file(fTreeMCMCfile);
+      fTreeMCMCfile->cd();
       Result();
       
       fTreeMCMC->Write();

--- a/core/RooMcmc.h
+++ b/core/RooMcmc.h
@@ -106,6 +106,7 @@ namespace HS{
   
       RooStats::MarkovChain* fChain =nullptr; //!
       RooDataSet* fChainData=nullptr;//!
+      TFile* fTreeMCMCfile=nullptr;//!
       TTree* fTreeMCMC=nullptr;//!
       Bool_t fCorrectForWeights=kTRUE;
       RooArgSet* fParams=nullptr;//!


### PR DESCRIPTION
`MCMCTree` is currently memory resident (i.e., it is created before the `TFile` to which it is written). The following errors occur (tested 6.24/02): 
```
Error in <TBranch::TBranch::Fill>: Failed to write out basket.

...
...

Error in <TTree::Fill>: Failed filling branch:MCMCTree.nll_MarkovChain_local_, nbytes=-1, entry=3988
 This error is symptomatic of a Tree created as a memory-resident Tree
 Instead of doing:
    TTree *T = new TTree(...)
    TFile *f = new TFile(...)
 you should do:
    TFile *f = new TFile(...)
    TTree *T = new TTree(...)

...
...

Error in <TBranch::WriteBasketImpl>: basket's WriteBuffer failed.
```
The proposed patch creates the `TFile` before the `MCMCTree`, which should force the tree to be disk resident, rather than memory resident. Further testing is needed before this PR can be marked ready.