### PR TITLE
Fix issue with output directory when using `Proof::Go()`

### DIFF
--- a/core/FitSelector.cpp
+++ b/core/FitSelector.cpp
@@ -50,8 +50,15 @@ namespace HS{
 
        
       if(!fInput) fInput=new TList();
-      TNamed *outdir=new TNamed("HSOUTDIR",fFitManager->SetUp().GetOutDir().Data());
-      fInput->Add(outdir);
+      auto outdir=dynamic_cast<TNamed*>(fInput->FindObject("HSOUTDIR"));
+      if(outdir) {
+        // reuse already existing entry for output directory
+        outdir->SetTitle(fFitManager->SetUp().GetOutDir().Data());
+      } else {
+        // create new entry for output directory
+        outdir=new TNamed("HSOUTDIR",fFitManager->SetUp().GetOutDir().Data());
+        fInput->Add(outdir);
+      }
       fFitManager->PreRun();
     }
 


### PR DESCRIPTION
If `Proof::Go()` is called for different data sets in the same ROOT session, `FitSelector::Begin()` created duplicate `TNamed` instances all named `HSOUTDIR`. This caused `fInput->FindObject("HSOUTDIR")` in `FitSelector::SlaveBegin()` to pick up stale data so that the fit results were written to the wrong directory. This pull request fixes this by reusing existing `HSOUTDIR` instances.