### PR TITLE
fix: build `V2` against ROOT v6.38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 hipo4
 lib
 man
+/install
 
 # hipo source
 ##############

--- a/core/BootStrapper.h
+++ b/core/BootStrapper.h
@@ -3,6 +3,7 @@
 #include <TTree.h>
 #include <TString.h>
 
+#include <cmath>
 #include <utility>
 
 namespace HS{

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(${BRUFIT_LIB}
 )
 
 # Link against ROOT targets
-target_link_libraries(${BRUFIT_LIB} PUBLIC ROOT::RooFit ROOT::RooFitCore ROOT::RooStats ROOT::MathMore ROOT::Proof ROOT::Minuit2 ROOT::Tree ROOT::TreePlayer ROOT::Matrix ROOT::Physics)
+target_link_libraries(${BRUFIT_LIB} PUBLIC ROOT::RooFit ROOT::RooFitCore ROOT::RooStats ROOT::MathMore ROOT::Minuit2 ROOT::Tree ROOT::TreePlayer ROOT::Matrix ROOT::Physics)
 
 # --- 4. Installation ---
 install(TARGETS ${BRUFIT_LIB}


### PR DESCRIPTION
1. remove one more PROOF reference in CMake config
2. include missing header
3. add `install/` prefix to `.gitignore` (for convenience)

With 1 and 2, I can build against ROOT 6.38 (but I have not tested runtime).

This PR targets the `V2` branch.